### PR TITLE
[Core] Fix incorrect write version when it is written from 2 procs

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -50,6 +50,9 @@ Limitation:
 
 Issues:
 - ray.get on reused plasma buffer works with numpy but not with bytes (and probably other objects)
+- max_readers currently hangs if we don't read as many as max_readers. We should call it target_read instead or change the logic.
+- If we write and do not read, it hangs.
+- Chain is not working (run more than 1 task at actor at a time.). Expected?
 
 
 To port DAG code:

--- a/dag-benchmarks/max_reader_bug.py
+++ b/dag-benchmarks/max_reader_bug.py
@@ -1,0 +1,21 @@
+import ray
+import time
+
+"""
+max_readers sound like it can have up to 2 readers, but it
+actually means if you don't read it twice, it cannot upgrade the version and
+write a new value.
+
+We should either change the name (if it is expected) or fix it if it is a bug.
+"""
+# Basic case
+ray.init(num_cpus=1)
+ref = ray.put(b"000000000000", max_readers=2)
+val = ray.get(ref)
+print(val)
+assert val == b"000000000000"
+ray.release(ref)
+ray.worker.global_worker.put_object(b"1", object_ref=ref, max_readers=2)
+# hangs
+val = ray.get(ref)
+print(val)

--- a/dag-benchmarks/test_dag_output_size.py
+++ b/dag-benchmarks/test_dag_output_size.py
@@ -1,0 +1,53 @@
+import os
+import time
+
+import ray
+
+from ray.dag import InputNode, OutputNode
+from ray.dag.compiled_dag_node import RayCompiledExecutor
+
+
+@ray.remote
+class Actor(RayCompiledExecutor):
+    def __init__(self, init_value):
+        print("__init__ PID", os.getpid())
+        self.i = init_value
+
+    def get(self, x):
+        return x
+
+    def inc(self, x):
+        return x + b"1"
+
+
+init_val = 10
+actors = [Actor.remote(init_val) for _ in range(1)]
+
+with InputNode() as i:
+    out = [a.inc.bind(i) for a in actors]
+    dag = OutputNode(out)
+
+for _ in range(10):
+    input_val = b"hello"
+    refs = dag.execute(input_val, compiled=True)
+    val = ray.get(refs)[0]
+    assert input_val + b"1" == val
+    for ref in refs:
+        ray.release(ref)
+
+# TODO: NOT working.
+# Test different outputs chained.
+# with InputNode() as i:
+#     out = [a.inc.bind(i) for a in actors]
+#     for _ in range(3):
+#         out = [a.inc.bind(o) for o, a in zip(out, actors)]
+#     dag = OutputNode(out)
+
+# for _ in range(3):
+#     input_val = b"hello"
+#     expected = b"hello111"
+#     refs = dag.execute(input_val, compiled=True)
+#     val = ray.get(refs)[0]
+#     assert expected == val
+#     for ref in refs:
+#         ray.release(ref)

--- a/dag-benchmarks/test_put_different_size.py
+++ b/dag-benchmarks/test_put_different_size.py
@@ -1,11 +1,18 @@
 import ray
+import time
 
 # Basic case
-ray.init()
-ref = ray.put(b"000000000", max_readers=1)
+ray.init(num_cpus=1)
+ref = ray.put(b"000000000000", max_readers=1)
 val = ray.get(ref)
 print(val)
-assert val == b"000000000"
+assert val == b"000000000000"
+ray.release(ref)
+
+ray.worker.global_worker.put_object(b"world", object_ref=ref, max_readers=1)
+val = ray.get(ref)
+print(val)
+assert val == b"world"
 ray.release(ref)
 
 ray.worker.global_worker.put_object(b"world", object_ref=ref, max_readers=1)

--- a/dag-benchmarks/test_put_multi_process.py
+++ b/dag-benchmarks/test_put_multi_process.py
@@ -1,0 +1,49 @@
+import ray
+import time
+
+"""
+Verify put in 2 different processes work.
+"""
+ray.init(num_cpus=1)
+
+print("Test Write input from driver -> Read & Write from worker -> Read output from driver")
+expected_input = b"000000000000"
+ref = ray.put(expected_input, max_readers=1)
+print(ref)
+
+@ray.remote
+class A:
+    def f(self, refs, expected_input, output_val):
+        ref = refs[0]
+        val = ray.get(refs[0])
+        assert val == expected_input, val
+        ray.release(ref)
+        ray.worker.global_worker.put_object(output_val, object_ref=ref, max_readers=1)
+
+
+a = A.remote()
+time.sleep(1)
+output_val = b"0"
+b = a.f.remote([ref], expected_input, output_val)
+ray.get(b)
+val = ray.get(ref)
+assert output_val == val
+ray.release(ref)
+
+print("Test Write input from driver twice -> Read & Write from worker -> Read output from driver")
+# Test write twice.
+ref = ray.put(b"000000000000", max_readers=1)
+assert b"000000000000" == ray.get(ref)
+ray.release(ref)
+print(ref)
+expected_input = b"1"
+ray.worker.global_worker.put_object(b"1", object_ref=ref, max_readers=1)
+
+a = A.remote()
+time.sleep(1)
+expected_output = b"23"
+b = a.f.remote([ref], expected_input, expected_output)
+ray.get(b)
+val = ray.get(ref)
+assert expected_output == val
+ray.release(ref)

--- a/python/ray/dag/compiled_dag_node.py
+++ b/python/ray/dag/compiled_dag_node.py
@@ -5,9 +5,10 @@ from collections import defaultdict
 import ray
 
 
-MAX_BUFFER_SIZE = 1 * 1e9
+MAX_BUFFER_SIZE = int(100 * 1e6) # 100MB
 
 def allocate_shared_output_buffer(buffer_size_bytes: int = MAX_BUFFER_SIZE):
+    assert isinstance(MAX_BUFFER_SIZE, int)
     ref = ray.put(b"0" * buffer_size_bytes, max_readers=1)
     # TODO(swang): Sleep to make sure that the object store sees the Seal. Should
     # replace this with a better call to put reusable objects, and have the object
@@ -30,6 +31,13 @@ class CompiledTask:
     @property
     def max_readers(self):
         return len(self.dependent_node_idxs)
+
+    def __str__(self):
+        return f"""
+Node: {self.dag_node}
+Arguments: {self.args}
+Output: {self.output_ref}
+"""
 
 
 class CompiledDAG:

--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -131,7 +131,6 @@ class DAGNode(DAGNodeBase):
                 - resolved values representing user input at runtime
         """
         if compiled:
-            print(args)
             assert len(args) == 1, "Compiled DAGs support exactly one InputNode arg"
             input_ref, input_max_readers, output_ref = self.compile()
             ray.worker.global_worker.put_object(

--- a/src/ray/object_manager/common.h
+++ b/src/ray/object_manager/common.h
@@ -71,7 +71,9 @@ struct PlasmaObjectHeader {
   void Destroy();
   // Blocks until there are no more readers.
   // NOTE: This does not protect against multiple writers.
-  void WriteAcquire(int64_t write_version);
+  /// \param write_version The new version for write.
+  /// \param new_size The new data size of the object.
+  void WriteAcquire(int64_t write_version, uint64_t new_size);
   // Call after completing a write to signal to max_readers many readers.
   void WriteRelease(int64_t write_version, int64_t max_readers);
   // Blocks until the given version is ready to read.
@@ -80,10 +82,6 @@ struct PlasmaObjectHeader {
   // writer. This is not necessary to call for objects that have
   // max_readers=-1.
   void ReadRelease(int64_t read_version);
-  // Update the data size of the plasma object.
-  // This has to be called only when writer lock is acquired
-  // via WriteAcquire.
-  void UpdateDataSize(uint64_t size);
   // Get the data size of the plasma object.
   // This has to be called only when reader lock is acquired
   // via ReadAcquire.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
