### PR TITLE
[core][experimental] Support for GPU tensors nested inside other data

### DIFF
--- a/python/ray/dag/dag_node.py
+++ b/python/ray/dag/dag_node.py
@@ -66,7 +66,17 @@ class DAGNode(DAGNodeBase):
         self._type_hint: Optional[ChannelOutputType] = ChannelOutputType()
 
     def with_type_hint(self, typ: ChannelOutputType):
+        old_contains_typ = self._type_hint.contains_type
         self._type_hint = copy.deepcopy(typ)
+        if old_contains_typ is not None and typ.contains_type is None:
+            # The contained type was set before the return
+            # type, and the new return type doesn't have a
+            # contained type set.
+            self._type_hint.set_contains_type(old_contains_typ)
+        return self
+
+    def with_contains_type_hint(self, typ: ChannelOutputType):
+        self._type_hint.set_contains_type(typ)
         return self
 
     @property

--- a/python/ray/experimental/channel/common.py
+++ b/python/ray/experimental/channel/common.py
@@ -16,13 +16,26 @@ _context_lock = threading.Lock()
 
 @PublicAPI(stability="alpha")
 class ChannelOutputType:
+    def __init__(self):
+        self._contains_type: Optional["ChannelOutputType"] = None
+
     def register_custom_serializer(self) -> None:
         """
-        Register any custom serializers needed to pass data of this type. This
-        method should be run on the reader(s) and writer of a channel, which
-        are the driver and/or Ray actors.
+        Register any custom serializers needed to pass data of this type.
         """
-        pass
+        if self._contains_type is not None:
+            self._contains_type.register_custom_serializer()
+
+    @property
+    def contains_type(self) -> "ChannelOutputType":
+        return self._contains_type
+
+    def set_contains_type(self, typ: "ChannelOutputType") -> None:
+        from ray.experimental.channel.torch_tensor_type import TorchTensorType
+
+        if typ is not None and not isinstance(typ, TorchTensorType):
+            raise ValueError("Contained type must be of type TorchTensorType")
+        self._contains_type = typ
 
     def create_channel(
         self,
@@ -44,6 +57,10 @@ class ChannelOutputType:
         raise NotImplementedError
 
     def requires_nccl(self) -> bool:
+        if self._contains_type is not None:
+            if self._contains_type.requires_nccl():
+                return True
+
         # By default, channels do not require NCCL.
         return False
 

--- a/python/ray/experimental/channel/serialization_context.py
+++ b/python/ray/experimental/channel/serialization_context.py
@@ -1,8 +1,11 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Union
 
 if TYPE_CHECKING:
     import numpy as np
     import torch
+
+    from ray.experimenal.channel import ChannelOutputType
+    from ray.experimental.channel.torch_tensor_type import TorchTensorType
 
 
 class _SerializationContext:
@@ -10,6 +13,9 @@ class _SerializationContext:
         self.torch_device: Optional["torch.device"] = None
         self.use_external_transport: bool = False
         self.tensors: List["torch.Tensor"] = []
+
+    def set_use_external_transport(self, use_external_transport: bool) -> None:
+        self.use_external_transport = use_external_transport
 
     def set_torch_device(self, torch_device: "torch.device") -> None:
         self.torch_device = torch_device
@@ -19,7 +25,19 @@ class _SerializationContext:
         self.tensors = tensors
         return prev_tensors
 
-    def serialize_tensor(self, tensor: "torch.Tensor") -> "np.ndarray":
+    def serialize_tensor(self, tensor: "torch.Tensor") -> Union[int, "np.ndarray"]:
+        from ray.experimental.channel.torch_tensor_type import TorchTensorType
+
+        if self.use_external_transport:
+            # Add the actual tensor to a buffer. The buffer of tensors should
+            # later be popped by the caller and sent via external transport.
+            self.tensors.append(tensor)
+            # Return a placeholder.
+            return len(self.tensors) - 1
+
+        return self.serialize_to_numpy(tensor)
+
+    def serialize_to_numpy(self, tensor: "torch.Tensor") -> "np.ndarray":
         # Transfer through Ray's shared memory store for now.
         # TODO(swang): This requires two copies, one to transfer from GPU to
         # CPU and another from CPU to shared memory. Ideally we should elide
@@ -30,7 +48,15 @@ class _SerializationContext:
 
         return tensor.numpy()
 
-    def deserialize_tensor(self, np_array: "np.ndarray"):
+    def deserialize_tensor(self, val: Union["np.ndarray", int]):
+        # Found a placeholder for a tensor that was serialized via NCCL.
+        # Replace it with the corresponding deserialized tensor.
+        if isinstance(val, int):
+            return self.tensors[val]
+
+        return self.deserialize_from_numpy(val)
+
+    def deserialize_from_numpy(self, np_array: "np.ndarray"):
         import torch
 
         # TODO(swang): Support local P2P transfers if available.

--- a/python/ray/experimental/channel/shared_memory_channel.py
+++ b/python/ray/experimental/channel/shared_memory_channel.py
@@ -4,7 +4,11 @@ from typing import Any, List, Optional, Union
 
 import ray
 from ray.experimental.channel.common import ChannelInterface, ChannelOutputType
+from ray.experimental.channel.torch_tensor_type import TorchTensorType
 from ray.util.annotations import PublicAPI
+from ray._raylet import (
+        SerializedObject,
+        )
 
 # Logger for this module. It should be configured at the entry point
 # into the program using Ray. Ray provides a default configuration at
@@ -106,7 +110,32 @@ class SharedMemoryType(ChannelOutputType):
             A ChannelInterface that can be used to pass data
                 of this type.
         """
+        if self._contains_type is not None:
+            assert isinstance(
+                self._contains_type, TorchTensorType
+            ), "_contains_type must be of type TorchTensorType"
+
+            from ray.experimental.channel.torch_tensor_nccl_channel import (
+                NestedTorchTensorNcclChannel,
+            )
+
+            if self._contains_type.transport == TorchTensorType.NCCL:
+                cpu_data_typ = SharedMemoryType(buffer_size_bytes=self.buffer_size_bytes)
+                return NestedTorchTensorNcclChannel(
+                    writer,
+                    readers,
+                    gpu_data_typ=self._contains_type,
+                    cpu_data_typ=cpu_data_typ,
+                )
+
         return Channel(writer, readers)
+
+    def set_nccl_group_id(self, group_id: str) -> None:
+        assert self.requires_nccl()
+
+        # Shared memory channels don't need NCCL but they can
+        # contain objects that use NCCL.
+        self._contains_type.set_nccl_group_id(group_id)
 
 
 @PublicAPI(stability="alpha")
@@ -311,17 +340,20 @@ class Channel(ChannelInterface):
     def write(self, value: Any):
         self.ensure_registered_as_writer()
 
-        try:
-            serialized_value = self._worker.get_serialization_context().serialize(value)
-        except TypeError as e:
-            sio = io.StringIO()
-            ray.util.inspect_serializability(value, print_file=sio)
-            msg = (
-                "Could not serialize the put value "
-                f"{repr(value)}:\n"
-                f"{sio.getvalue()}"
-            )
-            raise TypeError(msg) from e
+        if not isinstance(value, SerializedObject):
+            try:
+                serialized_value = self._worker.get_serialization_context().serialize(value)
+            except TypeError as e:
+                sio = io.StringIO()
+                ray.util.inspect_serializability(value, print_file=sio)
+                msg = (
+                    "Could not serialize the put value "
+                    f"{repr(value)}:\n"
+                    f"{sio.getvalue()}"
+                )
+                raise TypeError(msg) from e
+        else:
+            serialized_value = value
 
         self._worker.core_worker.experimental_channel_put_serialized(
             serialized_value,

--- a/python/ray/experimental/channel/torch_tensor_type.py
+++ b/python/ray/experimental/channel/torch_tensor_type.py
@@ -94,6 +94,9 @@ class TorchTensorType(ChannelOutputType):
             deserializer=deserialize,
         )
 
+    def set_contains_type(self, typ: "ChannelOutputType") -> None:
+        raise ValueError("TorchTensorType cannot contain other types")
+
     def create_channel(
         self,
         writer: Optional["ray.actor.ActorHandle"],


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

## Why are these changes needed?

Depends on https://github.com/ray-project/ray/pull/45332. Adds a nested TorchTensorType so that tensors stored inside a Python object can be passed via NCCL using the following syntax:

```python
    with InputNode() as inp:
        dag = sender.send.bind(inp)
        dag = dag.with_contains_type_hint(TorchTensorType(transport="nccl"))
        dag = receiver.recv.bind(dag)

    compiled_dag = dag.experimental_compile()
```

`with_contains_type_hint` indicates that the value returned by that DAG node contains one or more torch.Tenors that should be transferred via NCCL. We implement this using a shared memory channel to pass CPU data, and the existing NCCL channel. If the TorchTensorType doesn't have a shape and dtype specified, we use an additional shared memory channel to pass metadata for the serialized tensors.

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
